### PR TITLE
browse-url-default-handlers doesn't exists yet on Emacs 27

### DIFF
--- a/osm.el
+++ b/osm.el
@@ -1598,7 +1598,8 @@ If prefix ARG is given, store url as Elisp expression."
     (message "Saved in the kill ring: %s" url)))
 
 ;;;###autoload
-(add-to-list 'browse-url-default-handlers '("\\`geo:" . osm))
+(when (>= emacs-major-version 28)
+  (add-to-list 'browse-url-default-handlers '("\\`geo:" . osm)))
 
 (dolist (sym (list #'osm-center #'osm-up #'osm-down #'osm-left #'osm-right
                    #'osm-up-up #'osm-down-down #'osm-left-left #'osm-right-right


### PR DESCRIPTION
The `browse-url-default-handlers` variable was introduced on Emacs 28, but the package only reqauires Emacs 27.1.
Apparently browse-url-browser-function could be used for the same thing, but it has slightly different semantics.
This change just makes the following error go away:

autoload-do-load: Symbol’s value as variable is void: browse-url-default-handlers

This is a trivial change, so I don't believe FSF paperwork is necessary.